### PR TITLE
Update langchain mongodb

### DIFF
--- a/libs/langchain-mongodb/langchain_mongodb/cache.py
+++ b/libs/langchain-mongodb/langchain_mongodb/cache.py
@@ -51,6 +51,7 @@ class MongoDBCache(BaseCache):
         self.client = _generate_mongo_client(connection_string)
         self.__database_name = database_name
         self.__collection_name = collection_name
+        self.chunk_collection = self.database[f"{self.__collection_name}_chunks"]
 
         if self.__collection_name not in self.database.list_collection_names(
             authorizedCollections=True
@@ -75,17 +76,69 @@ class MongoDBCache(BaseCache):
 
     def lookup(self, prompt: str, llm_string: str) -> Optional[RETURN_VAL_TYPE]:
         """Look up based on prompt and llm_string."""
-        return_doc = (
+        main_doc = (
             self.collection.find_one(self._generate_keys(prompt, llm_string)) or {}
         )
-        return_val = return_doc.get(self.RETURN_VAL)
-        return _loads_generations(return_val) if return_val else None  # type: ignore
+
+        if not main_doc:
+            return None
+
+        if not main_doc.get("is_chunked"):
+            return_val = main_doc.get(self.RETURN_VAL)
+            return _loads_generations(return_val) if return_val else None
+
+        chunk_key = main_doc.get("chunk_key")
+        num_chunks = main_doc.get("num_chunks")
+        if not chunk_key or not num_chunks:
+            return None
+
+        chunk_keys = [f"{chunk_key}_part_{i + 1}" for i in range(num_chunks)]
+        chunk_docs_cursor = self.chunk_collection.find({"_id": {"$in": chunk_keys}})
+        docs_by_id = {doc["_id"]: doc["value"] for doc in chunk_docs_cursor}
+
+        if len(docs_by_id) != num_chunks:
+            return None
+
+        reassembled = "".join(docs_by_id[key] for key in chunk_keys)
+        return _loads_generations(reassembled)  # type: ignore
 
     def update(self, prompt: str, llm_string: str, return_val: RETURN_VAL_TYPE) -> None:
         """Update cache based on prompt and llm_string."""
+        from bson import ObjectId
+
+        serialized_val = _dumps_generations(return_val)
+        chunk_size = 800 * 1024
+
+        keys = self._generate_keys(prompt, llm_string)
+
+        if len(serialized_val.encode("utf-8")) <= chunk_size:
+            self.collection.update_one(
+                keys,
+                {"$set": {self.RETURN_VAL: serialized_val, "is_chunked": False}},
+                upsert=True,
+            )
+            return
+
+        chunk_key = str(ObjectId())
+        chunks = [
+            serialized_val[i : i + chunk_size]
+            for i in range(0, len(serialized_val), chunk_size)
+        ]
+        chunk_docs = [
+            {"_id": f"{chunk_key}_part_{i + 1}", "value": chunk}
+            for i, chunk in enumerate(chunks)
+        ]
+        self.chunk_collection.insert_many(chunk_docs)
+
         self.collection.update_one(
-            {**self._generate_keys(prompt, llm_string)},
-            {"$set": {self.RETURN_VAL: _dumps_generations(return_val)}},
+            keys,
+            {
+                "$set": {
+                    "is_chunked": True,
+                    "chunk_key": chunk_key,
+                    "num_chunks": len(chunks),
+                }
+            },
             upsert=True,
         )
 
@@ -143,6 +196,9 @@ class MongoDBAtlasSemanticCache(BaseCache, MongoDBAtlasVectorSearch):
         """
         client = _generate_mongo_client(connection_string)
         self.collection = client[database_name][collection_name]
+        self.chunk_collection = self.collection.database[
+            f"{self.collection.name}_chunks"
+        ]
         self.score_threshold = score_threshold
         self._wait_until_ready = wait_until_ready
         super().__init__(
@@ -167,8 +223,28 @@ class MongoDBAtlasSemanticCache(BaseCache, MongoDBAtlasVectorSearch):
             post_filter_pipeline=post_filter_pipeline,
         )
         if search_response:
-            return_val = search_response[0][0].metadata.get(self.RETURN_VAL)
-            response = _loads_generations(return_val) or return_val  # type: ignore
+            metadata = search_response[0][0].metadata
+            if not metadata.get("is_chunked"):
+                return_val = metadata.get(self.RETURN_VAL)
+                response = _loads_generations(return_val) or return_val  # type: ignore
+                return response
+
+            chunk_key = metadata.get("chunk_key")
+            num_chunks = metadata.get("num_chunks")
+            if not chunk_key or not num_chunks:
+                return None
+
+            chunk_keys = [f"{chunk_key}_part_{i + 1}" for i in range(num_chunks)]
+            chunk_docs_cursor = self.chunk_collection.find(
+                {"_id": {"$in": chunk_keys}}
+            )
+            docs_by_id = {doc["_id"]: doc["value"] for doc in chunk_docs_cursor}
+
+            if len(docs_by_id) != num_chunks:
+                return None
+
+            reassembled = "".join(docs_by_id[key] for key in chunk_keys)
+            response = _loads_generations(reassembled) or reassembled  # type: ignore
             return response
         return None
 
@@ -180,15 +256,36 @@ class MongoDBAtlasSemanticCache(BaseCache, MongoDBAtlasVectorSearch):
         wait_until_ready: Optional[float] = None,
     ) -> None:
         """Update cache based on prompt and llm_string."""
-        self.add_texts(
-            [prompt],
-            [
-                {
-                    self.LLM: llm_string,
-                    self.RETURN_VAL: _dumps_generations(return_val),
-                }
-            ],
-        )
+        from bson import ObjectId
+
+        serialized_val = _dumps_generations(return_val)
+        chunk_size = 800 * 1024
+
+        if len(serialized_val.encode("utf-8")) <= chunk_size:
+            metadata = {
+                self.LLM: llm_string,
+                self.RETURN_VAL: serialized_val,
+                "is_chunked": False,
+            }
+        else:
+            chunk_key = str(ObjectId())
+            chunks = [
+                serialized_val[i : i + chunk_size]
+                for i in range(0, len(serialized_val), chunk_size)
+            ]
+            chunk_docs = [
+                {"_id": f"{chunk_key}_part_{i + 1}", "value": chunk}
+                for i, chunk in enumerate(chunks)
+            ]
+            self.chunk_collection.insert_many(chunk_docs)
+            metadata = {
+                self.LLM: llm_string,
+                "is_chunked": True,
+                "chunk_key": chunk_key,
+                "num_chunks": len(chunks),
+            }
+
+        self.add_texts([prompt], [metadata])
         wait = self._wait_until_ready if wait_until_ready is None else wait_until_ready
 
         def is_indexed() -> bool:

--- a/libs/langchain-mongodb/langchain_mongodb/docstores.py
+++ b/libs/langchain-mongodb/langchain_mongodb/docstores.py
@@ -35,6 +35,9 @@ class MongoDBDocStore(BaseStore):
 
     def __init__(self, collection: Collection, text_key: str = "page_content") -> None:
         self.collection = collection
+        self.chunk_collection = self.collection.database[
+            f"{self.collection.name}_chunks"
+        ]
         self._text_key = text_key
 
         _append_client_metadata(self.collection.database.client)
@@ -81,10 +84,35 @@ class MongoDBDocStore(BaseStore):
         """
         found_docs = {}
         for res in self.collection.find({"_id": {"$in": keys}}):
-            text = res.pop(self._text_key)
             key = res.pop("_id")
-            make_serializable(res)
-            found_docs[key] = Document(page_content=text, metadata=res)
+            if not res.get("is_chunked"):
+                text = res.pop(self._text_key)
+                make_serializable(res)
+                found_docs[key] = Document(page_content=text, metadata=res)
+            else:
+                chunk_key = res.get("chunk_key")
+                num_chunks = res.get("num_chunks")
+                if not chunk_key or not num_chunks:
+                    continue
+
+                chunk_keys = [f"{chunk_key}_part_{i + 1}" for i in range(num_chunks)]
+                chunk_docs_cursor = self.chunk_collection.find(
+                    {"_id": {"$in": chunk_keys}}
+                )
+                docs_by_id = {doc["_id"]: doc["value"] for doc in chunk_docs_cursor}
+
+                if len(docs_by_id) != num_chunks:
+                    continue
+
+                from bson import BSON
+
+                reassembled_bytes = b"".join(docs_by_id[k] for k in chunk_keys)
+                reassembled_doc = BSON(reassembled_bytes).decode()
+                text = reassembled_doc.pop(self._text_key)
+                reassembled_doc.pop("_id", None)
+                make_serializable(reassembled_doc)
+                found_docs[key] = Document(page_content=text, metadata=reassembled_doc)
+
         return [found_docs.get(key, None) for key in keys]
 
     def mset(
@@ -154,3 +182,35 @@ class MongoDBDocStore(BaseStore):
             for i, t, m in zip(ids, texts, metadatas, strict=True)
         ]
         self.collection.insert_many(to_insert)  # type: ignore
+        from bson import BSON, ObjectId
+
+        to_insert = []
+        chunk_size = 800 * 1024
+        for i, t, m in zip(ids, texts, metadatas, strict=True):
+            doc = {"_id": i, self._text_key: t, **m}
+            serialized_doc = BSON.encode(doc)
+
+            if len(serialized_doc) <= chunk_size:
+                to_insert.append({"is_chunked": False, **doc})
+            else:
+                chunk_key = str(ObjectId())
+                chunks = [
+                    serialized_doc[j : j + chunk_size]
+                    for j in range(0, len(serialized_doc), chunk_size)
+                ]
+                chunk_docs = [
+                    {"_id": f"{chunk_key}_part_{j + 1}", "value": chunk}
+                    for j, chunk in enumerate(chunks)
+                ]
+                self.chunk_collection.insert_many(chunk_docs)
+
+                to_insert.append(
+                    {
+                        "_id": i,
+                        "is_chunked": True,
+                        "chunk_key": chunk_key,
+                        "num_chunks": len(chunks),
+                    }
+                )
+        if to_insert:
+            self.collection.insert_many(to_insert)

--- a/libs/langchain-mongodb/langchain_mongodb/vectorstores.py
+++ b/libs/langchain-mongodb/langchain_mongodb/vectorstores.py
@@ -24,10 +24,10 @@ from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
 from langchain_core.runnables.config import run_in_executor
 from langchain_core.vectorstores import VectorStore
-from pymongo import MongoClient
+from pymongo import MongoClient, ReplaceOne
 from pymongo.collection import Collection
 from pymongo.errors import CollectionInvalid, ConfigurationError
-from pymongo_search_utils import bulk_embed_and_insert_texts
+# from pymongo_search_utils import bulk_embed_and_insert_texts
 
 from langchain_mongodb.embeddings import AutoEmbeddings
 from langchain_mongodb.index import (
@@ -282,6 +282,10 @@ class MongoDBAtlasVectorSearch(VectorStore):
                to be ready.
         """
         self._collection = collection
+        self.chunk_collection = self._collection.database[
+            f"{self._collection.name}_chunks"
+        ]
+        self._embedding = embedding
         self._index_name = index_name
         self._text_key = text_key if isinstance(text_key, str) else text_key[0]
         self._embedding_key = embedding_key
@@ -499,16 +503,56 @@ class MongoDBAtlasVectorSearch(VectorStore):
 
         See add_texts for additional details.
         """
-        return bulk_embed_and_insert_texts(
-            texts=texts,
-            metadatas=metadatas,
-            embedding_func=self._embedding.embed_documents,
-            collection=self._collection,
-            text_key=self._text_key,
-            embedding_key="" if self._embedding_key is None else self._embedding_key,
-            ids=ids,
-            autoembedding=self._is_autoembedding,
-        )
+        from bson import BSON
+
+        if not texts:
+            return []
+        # Compute embedding vectors
+        embeddings = self._embedding.embed_documents(list(texts))
+        if not ids:
+            ids = [str(ObjectId()) for _ in range(len(list(texts)))]
+
+        operations = []
+        chunk_size = 800 * 1024
+
+        for i, t, m, embedding in zip(ids, texts, metadatas, embeddings):
+            doc = {
+                "_id": str_to_oid(i),
+                self._text_key: t,
+                self._embedding_key: embedding,
+                **m,
+            }
+            serialized_doc = BSON.encode(doc)
+
+            if len(serialized_doc) <= chunk_size:
+                operations.append(ReplaceOne({"_id": doc["_id"]}, doc, upsert=True))
+            else:
+                chunk_key = str(ObjectId())
+                chunks = [
+                    serialized_doc[j : j + chunk_size]
+                    for j in range(0, len(serialized_doc), chunk_size)
+                ]
+                chunk_docs = [
+                    {"_id": f"{chunk_key}_part_{j + 1}", "value": chunk}
+                    for j, chunk in enumerate(chunks)
+                ]
+                self.chunk_collection.insert_many(chunk_docs)
+
+                pointer_doc = {
+                    "_id": str_to_oid(i),
+                    "is_chunked": True,
+                    "chunk_key": chunk_key,
+                    "num_chunks": len(chunks),
+                    self._embedding_key: embedding,
+                }
+                operations.append(
+                    ReplaceOne({"_id": pointer_doc["_id"]}, pointer_doc, upsert=True)
+                )
+
+        # insert the documents in MongoDB Atlas
+        result = self._collection.bulk_write(operations)
+        assert result.upserted_ids is not None
+        return [oid_to_str(_id) for _id in result.upserted_ids.values()]
 
     def add_documents(
         self,
@@ -895,25 +939,43 @@ class MongoDBAtlasVectorSearch(VectorStore):
         # Format
         missing_text_key = False
         for res in cursor:
-            if self._text_key not in res:
-                missing_text_key = True
-                continue
-            text = res.pop(self._text_key)
-            score = res.pop("score")
-            make_serializable(res)
-            docs.append(
-                (Document(page_content=text, metadata=res, id=res["_id"]), score)
-            )
+            if not res.get("is_chunked"):
+                if self._text_key not in res:
+                    continue
+                text = res.pop(self._text_key)
+                score = res.pop("score")
+                make_serializable(res)
+                docs.append(
+                    (Document(page_content=text, metadata=res, id=res["_id"]), score)
+                )
+            else:
+                chunk_key = res.get("chunk_key")
+                num_chunks = res.get("num_chunks")
+                if not chunk_key or not num_chunks:
+                    continue
 
-        if (
-            missing_text_key
-            and not len(docs)
-            and self._collection.count_documents({}) > 0
-        ):
-            warnings.warn(
-                f"Could not find any documents with the text_key: '{self._text_key}'",
-                stacklevel=1,
-            )
+                chunk_keys = [f"{chunk_key}_part_{i + 1}" for i in range(num_chunks)]
+                chunk_docs_cursor = self.chunk_collection.find(
+                    {"_id": {"$in": chunk_keys}}
+                )
+                docs_by_id = {doc["_id"]: doc["value"] for doc in chunk_docs_cursor}
+
+                if len(docs_by_id) != num_chunks:
+                    continue
+
+                from bson import BSON
+
+                reassembled_bytes = b"".join(docs_by_id[key] for key in chunk_keys)
+                reassembled_doc = BSON(reassembled_bytes).decode()
+                text = reassembled_doc.pop(self._text_key)
+                reassembled_doc.pop("_id", None)
+                score = res.pop("score")
+                # Combine pointer metadata with reassembled metadata
+                res.update(reassembled_doc)
+                make_serializable(res)
+                docs.append(
+                    (Document(page_content=text, metadata=res, id=res["_id"]), score)
+                )
         return docs
 
     def create_vector_search_index(

--- a/libs/langgraph-checkpoint-mongodb/langgraph/checkpoint/mongodb/aio.py
+++ b/libs/langgraph-checkpoint-mongodb/langgraph/checkpoint/mongodb/aio.py
@@ -473,7 +473,8 @@ class AsyncMongoDBSaver(BaseCheckpointSaver):
                     upsert=True,
                 )
             )
-        await self.writes_collection.bulk_write(operations)
+        for i in range(0, len(operations), 1000):
+            await self.writes_collection.bulk_write(operations[i : i + 1000])
 
     async def adelete_thread(
         self,

--- a/libs/langgraph-checkpoint-mongodb/langgraph/checkpoint/mongodb/aio.py
+++ b/libs/langgraph-checkpoint-mongodb/langgraph/checkpoint/mongodb/aio.py
@@ -99,10 +99,6 @@ class AsyncMongoDBSaver(BaseCheckpointSaver):
         self.loop = asyncio.get_running_loop()
         self.ttl = ttl
 
-        # append_metadata was added in PyMongo 4.14.0, but is a valid database name on earlier versions
-        if callable(getattr(self.client, "append_metadata", None)):
-            self.client.append_metadata(DRIVER_METADATA)
-
     async def _setup(self) -> None:
         """Create indexes if not present."""
         if self._setup_future is not None:

--- a/libs/langgraph-checkpoint-mongodb/langgraph/checkpoint/mongodb/aio.py
+++ b/libs/langgraph-checkpoint-mongodb/langgraph/checkpoint/mongodb/aio.py
@@ -1,0 +1,620 @@
+from __future__ import annotations
+
+import asyncio
+import builtins
+import sys
+import warnings
+from collections.abc import AsyncIterator, Iterator, Sequence
+from contextlib import asynccontextmanager
+from datetime import datetime
+from typing import Any, Optional, cast
+
+from langchain_core.runnables import RunnableConfig
+from pymongo import UpdateOne
+from pymongo.asynchronous.database import AsyncDatabase
+from pymongo.asynchronous.mongo_client import AsyncMongoClient
+
+from langgraph.checkpoint.base import (
+    WRITES_IDX_MAP,
+    BaseCheckpointSaver,
+    ChannelVersions,
+    Checkpoint,
+    CheckpointMetadata,
+    CheckpointTuple,
+    get_checkpoint_id,
+)
+
+from .utils import (
+    DRIVER_METADATA,
+    _append_client_metadata,
+    dumps_metadata,
+    loads_metadata,
+)
+
+if sys.version_info >= (3, 10):
+    anext = builtins.anext
+    aiter = builtins.aiter
+else:
+
+    async def anext(cls: Any) -> Any:
+        """Compatibility function until we drop 3.9 support: https://docs.python.org/3/library/functions.html#anext."""
+        return await cls.__anext__()
+
+    def aiter(cls: Any) -> Any:
+        """Compatibility function until we drop 3.9 support: https://docs.python.org/3/library/functions.html#anext."""
+        return cls.__aiter__()
+
+
+__all__ = ["AsyncMongoDBSaver"]
+
+
+class AsyncMongoDBSaver(BaseCheckpointSaver):
+    """A checkpoint saver that stores checkpoints in a MongoDB database asynchronously.
+
+    The synchronous MongoDBSaver has extended documentation, but
+    Asynchronous usage is shown below.
+
+    Examples:
+        >>> import asyncio
+        >>> from langgraph.checkpoint.mongodb.aio import AsyncMongoDBSaver
+        >>> from langgraph.graph import StateGraph
+
+        >>> async def main() -> None:
+        >>>     builder = StateGraph(int)
+        >>>     builder.add_node("add_one", lambda x: x + 1)
+        >>>     builder.set_entry_point("add_one")
+        >>>     builder.set_finish_point("add_one")
+        >>>     async with AsyncMongoDBSaver.from_conn_string("mongodb://localhost:27017") as memory:
+        >>>         graph = builder.compile(checkpointer=memory)
+        >>>         config = {"configurable": {"thread_id": "1"}}
+        >>>         input = 3
+        >>>         output = await graph.ainvoke(input, config)
+        >>>         print(f"{input=}, {output=}")
+
+        >>> if __name__ == "__main__":
+        >>>     asyncio.run(main())
+        input=3, output=4
+    """
+
+    client: AsyncMongoClient
+    db: AsyncDatabase
+
+    def __init__(
+        self,
+        client: AsyncMongoClient,
+        db_name: str = "checkpointing_db",
+        checkpoint_collection_name: str = "checkpoints_aio",
+        writes_collection_name: str = "checkpoint_writes_aio",
+        ttl: Optional[int] = None,
+        **kwargs: Any,
+    ) -> None:
+        warnings.warn(
+            f"{self.__class__.__name__} is deprecated and will be removed in 0.3.0 release. "
+            "Please use the async methods of MongoDBSaver instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__()
+        self.client = client
+        self.db = self.client[db_name]
+        self.checkpoint_collection = self.db[checkpoint_collection_name]
+        self.writes_collection = self.db[writes_collection_name]
+        self.chunk_collection = self.db[f"{checkpoint_collection_name}_chunks"]
+        self._setup_future: asyncio.Future | None = None
+        self.loop = asyncio.get_running_loop()
+        self.ttl = ttl
+
+        # append_metadata was added in PyMongo 4.14.0, but is a valid database name on earlier versions
+        _append_client_metadata(self.client)
+
+    async def _setup(self) -> None:
+        """Create indexes if not present."""
+        if self._setup_future is not None:
+            return await self._setup_future
+        self._setup_future = asyncio.Future()
+        if isinstance(self.client, AsyncMongoClient):
+            num_indexes = len(
+                await (await self.checkpoint_collection.list_indexes()).to_list()
+            )
+        else:
+            num_indexes = len(await self.checkpoint_collection.list_indexes().to_list())
+        if num_indexes < 2:
+            await self.checkpoint_collection.create_index(
+                keys=[("thread_id", 1), ("checkpoint_ns", 1), ("checkpoint_id", -1)],
+                unique=True,
+            )
+            if self.ttl:
+                await self.checkpoint_collection.create_index(
+                    keys=[("created_at", 1)],
+                    expireAfterSeconds=self.ttl,
+                )
+        if isinstance(self.client, AsyncMongoClient):
+            num_indexes = len(
+                await (await self.writes_collection.list_indexes()).to_list()
+            )
+        else:
+            num_indexes = len(await self.writes_collection.list_indexes().to_list())
+        if num_indexes < 2:
+            await self.writes_collection.create_index(
+                keys=[
+                    ("thread_id", 1),
+                    ("checkpoint_ns", 1),
+                    ("checkpoint_id", -1),
+                    ("task_id", 1),
+                    ("idx", 1),
+                ],
+                unique=True,
+            )
+            if self.ttl:
+                await self.writes_collection.create_index(
+                    keys=[("created_at", 1)],
+                    expireAfterSeconds=self.ttl,
+                )
+        self._setup_future.set_result(None)
+
+    @classmethod
+    @asynccontextmanager
+    async def from_conn_string(
+        cls,
+        conn_string: str,
+        db_name: str = "checkpointing_db",
+        checkpoint_collection_name: str = "checkpoints_aio",
+        writes_collection_name: str = "checkpoint_writes_aio",
+        ttl: Optional[int] = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[AsyncMongoDBSaver]:
+        """Create asynchronous checkpointer
+
+        This includes creation of collections and indexes if they don't exist
+        """
+        client: Optional[AsyncMongoClient] = None
+        try:
+            client = AsyncMongoClient(
+                conn_string,
+                driver=DRIVER_METADATA,
+            )
+            saver = AsyncMongoDBSaver(
+                client,
+                db_name,
+                checkpoint_collection_name,
+                writes_collection_name,
+                ttl,
+                **kwargs,
+            )
+            await saver._setup()
+            yield saver
+
+        finally:
+            if client:
+                await client.close()
+
+    async def aget_tuple(self, config: RunnableConfig) -> Optional[CheckpointTuple]:
+        """Get a checkpoint tuple from the database asynchronously.
+
+        This method retrieves a checkpoint tuple from the MongoDB database based on the
+        provided config. If the config contains a "checkpoint_id" key, the checkpoint with
+        the matching thread ID and checkpoint ID is retrieved. Otherwise, the latest checkpoint
+        for the given thread ID is retrieved.
+
+        Args:
+            config (RunnableConfig): The config to use for retrieving the checkpoint.
+
+        Returns:
+            Optional[CheckpointTuple]: The retrieved checkpoint tuple, or None if no matching checkpoint was found.
+        """
+        await self._setup()
+        thread_id = config["configurable"]["thread_id"]
+        checkpoint_ns = config["configurable"].get("checkpoint_ns", "")
+        if checkpoint_id := get_checkpoint_id(config):
+            query = {
+                "thread_id": thread_id,
+                "checkpoint_ns": checkpoint_ns,
+                "checkpoint_id": checkpoint_id,
+            }
+        else:
+            query = {"thread_id": thread_id, "checkpoint_ns": checkpoint_ns}
+
+        result = self.checkpoint_collection.find(
+            query, sort=[("checkpoint_id", -1)], limit=1
+        )
+        async for doc in result:
+            config_values = {
+                "thread_id": thread_id,
+                "checkpoint_ns": checkpoint_ns,
+                "checkpoint_id": doc["checkpoint_id"],
+            }
+            if not doc.get("is_chunked"):
+                serialized_checkpoint = doc["checkpoint"]
+            else:
+                chunk_key = doc.get("chunk_key")
+                num_chunks = doc.get("num_chunks")
+                if not chunk_key or not num_chunks:
+                    return None
+
+                chunk_keys = [f"{chunk_key}_part_{i + 1}" for i in range(num_chunks)]
+                chunk_docs_cursor = self.chunk_collection.find(
+                    {"_id": {"$in": chunk_keys}}
+                )
+                docs_by_id = {
+                    doc["_id"]: doc["value"] async for doc in chunk_docs_cursor
+                }
+
+                if len(docs_by_id) != num_chunks:
+                    return None
+
+                reassembled = b"".join(docs_by_id[key] for key in chunk_keys)
+                serialized_checkpoint = reassembled
+
+            checkpoint = self.serde.loads_typed((doc["type"], serialized_checkpoint))
+            serialized_writes = self.writes_collection.find(config_values)
+            pending_writes = [
+                (
+                    wrt["task_id"],
+                    wrt["channel"],
+                    self.serde.loads_typed((wrt["type"], wrt["value"])),
+                )
+                async for wrt in serialized_writes
+            ]
+            return CheckpointTuple(
+                {"configurable": config_values},
+                checkpoint,
+                loads_metadata(doc["metadata"]),
+                (
+                    {
+                        "configurable": {
+                            "thread_id": thread_id,
+                            "checkpoint_ns": checkpoint_ns,
+                            "checkpoint_id": doc["parent_checkpoint_id"],
+                        }
+                    }
+                    if doc.get("parent_checkpoint_id")
+                    else None
+                ),
+                pending_writes,
+            )
+
+    async def alist(
+        self,
+        config: Optional[RunnableConfig],
+        *,
+        filter: Optional[dict[str, Any]] = None,
+        before: Optional[RunnableConfig] = None,
+        limit: Optional[int] = None,
+    ) -> AsyncIterator[CheckpointTuple]:
+        """List checkpoints from the database asynchronously.
+
+        This method retrieves a list of checkpoint tuples from the MongoDB database based
+        on the provided config. The checkpoints are ordered by checkpoint ID in descending order (newest first).
+
+        Args:
+            config (Optional[RunnableConfig]): Base configuration for filtering checkpoints.
+            filter (Optional[dict[str, Any]]): Additional filtering criteria for metadata.
+            before (Optional[RunnableConfig]): If provided, only checkpoints before the specified checkpoint ID are returned. Defaults to None.
+            limit (Optional[int]): Maximum number of checkpoints to return.
+
+        Yields:
+            AsyncIterator[CheckpointTuple]: An asynchronous iterator of matching checkpoint tuples.
+        """
+        await self._setup()
+        query = {}
+        if config is not None:
+            if "thread_id" in config["configurable"]:
+                query["thread_id"] = config["configurable"]["thread_id"]
+            if "checkpoint_ns" in config["configurable"]:
+                query["checkpoint_ns"] = config["configurable"]["checkpoint_ns"]
+
+        if filter:
+            for key, value in filter.items():
+                query[f"metadata.{key}"] = dumps_metadata(value)
+
+        if before is not None:
+            query["checkpoint_id"] = {"$lt": before["configurable"]["checkpoint_id"]}
+
+        result = self.checkpoint_collection.find(
+            query, limit=0 if limit is None else limit, sort=[("checkpoint_id", -1)]
+        )
+
+        async for doc in result:
+            config_values = {
+                "thread_id": doc["thread_id"],
+                "checkpoint_ns": doc["checkpoint_ns"],
+                "checkpoint_id": doc["checkpoint_id"],
+            }
+            serialized_writes = self.writes_collection.find(config_values)
+            pending_writes = [
+                (
+                    wrt["task_id"],
+                    wrt["channel"],
+                    self.serde.loads_typed((wrt["type"], wrt["value"])),
+                )
+                async for wrt in serialized_writes
+            ]
+
+            yield CheckpointTuple(
+                config={
+                    "configurable": {
+                        "thread_id": doc["thread_id"],
+                        "checkpoint_ns": doc["checkpoint_ns"],
+                        "checkpoint_id": doc["checkpoint_id"],
+                    }
+                },
+                checkpoint=self.serde.loads_typed((doc["type"], doc["checkpoint"])),
+                metadata=loads_metadata(doc["metadata"]),
+                parent_config=(
+                    {
+                        "configurable": {
+                            "thread_id": doc["thread_id"],
+                            "checkpoint_ns": doc["checkpoint_ns"],
+                            "checkpoint_id": doc["parent_checkpoint_id"],
+                        }
+                    }
+                    if doc.get("parent_checkpoint_id")
+                    else None
+                ),
+                pending_writes=pending_writes,
+            )
+
+    async def aput(
+        self,
+        config: RunnableConfig,
+        checkpoint: Checkpoint,
+        metadata: CheckpointMetadata,
+        new_versions: ChannelVersions,
+    ) -> RunnableConfig:
+        """Save a checkpoint to the database asynchronously.
+
+        This method saves a checkpoint to the MongoDB database. The checkpoint is associated
+        with the provided config and its parent config (if any).
+
+        Args:
+            config (RunnableConfig): The config to associate with the checkpoint.
+            checkpoint (Checkpoint): The checkpoint to save.
+            metadata (CheckpointMetadata): Additional metadata to save with the checkpoint.
+            new_versions (ChannelVersions): New channel versions as of this write.
+
+        Returns:
+            RunnableConfig: Updated configuration after storing the checkpoint.
+        """
+        from bson import ObjectId
+
+        await self._setup()
+        thread_id = config["configurable"]["thread_id"]
+        checkpoint_ns = config["configurable"]["checkpoint_ns"]
+        checkpoint_id = checkpoint["id"]
+        type_, serialized_checkpoint = self.serde.dumps_typed(checkpoint)
+
+        chunk_size = 800 * 1024
+        if len(serialized_checkpoint) <= chunk_size:
+            doc = {
+                "parent_checkpoint_id": config["configurable"].get("checkpoint_id"),
+                "type": type_,
+                "checkpoint": serialized_checkpoint,
+                "metadata": dumps_metadata(metadata),
+                "is_chunked": False,
+            }
+        else:
+            chunk_key = str(ObjectId())
+            chunks = [
+                serialized_checkpoint[i : i + chunk_size]
+                for i in range(0, len(serialized_checkpoint), chunk_size)
+            ]
+            chunk_docs = [
+                {"_id": f"{chunk_key}_part_{i + 1}", "value": chunk}
+                for i, chunk in enumerate(chunks)
+            ]
+            await self.chunk_collection.insert_many(chunk_docs)
+            doc = {
+                "parent_checkpoint_id": config["configurable"].get("checkpoint_id"),
+                "type": type_,
+                "metadata": dumps_metadata(metadata),
+                "is_chunked": True,
+                "chunk_key": chunk_key,
+                "num_chunks": len(chunks),
+            }
+
+        upsert_query = {
+            "thread_id": thread_id,
+            "checkpoint_ns": checkpoint_ns,
+            "checkpoint_id": checkpoint_id,
+        }
+        if self.ttl:
+            doc["created_at"] = datetime.now()
+        # Perform your operations here
+        await self.checkpoint_collection.update_one(
+            upsert_query, {"$set": doc}, upsert=True
+        )
+        return {
+            "configurable": {
+                "thread_id": thread_id,
+                "checkpoint_ns": checkpoint_ns,
+                "checkpoint_id": checkpoint_id,
+            }
+        }
+
+    async def aput_writes(
+        self,
+        config: RunnableConfig,
+        writes: Sequence[tuple[str, Any]],
+        task_id: str,
+        task_path: str = "",
+    ) -> None:
+        """Store intermediate writes linked to a checkpoint asynchronously.
+
+        This method saves intermediate writes associated with a checkpoint to the database.
+
+        Args:
+            config (RunnableConfig): Configuration of the related checkpoint.
+            writes (Sequence[tuple[str, Any]]): List of writes to store, each as (channel, value) pair.
+            task_id (str): Identifier for the task creating the writes.
+            task_path (str): Path of the task creating the writes.
+        """
+        await self._setup()
+        thread_id = config["configurable"]["thread_id"]
+        checkpoint_ns = config["configurable"]["checkpoint_ns"]
+        checkpoint_id = config["configurable"]["checkpoint_id"]
+        set_method = (  # Allow replacement on existing writes only if there were errors.
+            "$set" if all(w[0] in WRITES_IDX_MAP for w in writes) else "$setOnInsert"
+        )
+        operations = []
+        for idx, (channel, value) in enumerate(writes):
+            upsert_query = {
+                "thread_id": thread_id,
+                "checkpoint_ns": checkpoint_ns,
+                "checkpoint_id": checkpoint_id,
+                "task_id": task_id,
+                "task_path": task_path,
+                "idx": WRITES_IDX_MAP.get(channel, idx),
+            }
+            if self.ttl:
+                upsert_query["created_at"] = datetime.now()
+            type_, serialized_value = self.serde.dumps_typed(value)
+            operations.append(
+                UpdateOne(
+                    upsert_query,
+                    {
+                        set_method: {
+                            "channel": channel,
+                            "type": type_,
+                            "value": serialized_value,
+                        }
+                    },
+                    upsert=True,
+                )
+            )
+        await self.writes_collection.bulk_write(operations)
+
+    async def adelete_thread(
+        self,
+        thread_id: str,
+    ) -> None:
+        """Delete all checkpoints and writes associated with a specific thread ID asynchronously.
+
+        Args:
+            thread_id (str): The thread ID whose checkpoints should be deleted.
+        """
+        # Delete all checkpoints associated with the thread ID
+        await self.checkpoint_collection.delete_many({"thread_id": thread_id})
+
+        # Delete all writes associated with the thread ID
+        await self.writes_collection.delete_many({"thread_id": thread_id})
+
+    def delete_thread(
+        self,
+        thread_id: str,
+    ) -> None:
+        """Delete all checkpoints and writes associated with a specific thread ID.
+
+        Args:
+            thread_id (str): The thread ID whose checkpoints should be deleted.
+        """
+        return asyncio.run_coroutine_threadsafe(
+            self.adelete_thread(thread_id), self.loop
+        ).result()
+
+    def list(
+        self,
+        config: Optional[RunnableConfig],
+        *,
+        filter: Optional[dict[str, Any]] = None,
+        before: Optional[RunnableConfig] = None,
+        limit: Optional[int] = None,
+    ) -> Iterator[CheckpointTuple]:
+        """List checkpoints from the database.
+
+        This method retrieves a list of checkpoint tuples from the MongoDB database
+         based on the provided config. The checkpoints are ordered by checkpoint ID in
+         descending order (newest first).
+
+        Args:
+            config (Optional[RunnableConfig]): Base configuration for filtering checkpoints.
+            filter (Optional[dict[str, Any]]): Additional filtering criteria for metadata.
+            before (Optional[RunnableConfig]): If provided, only checkpoints before the specified checkpoint ID are returned. Defaults to None.
+            limit (Optional[int]): Maximum number of checkpoints to return.
+
+        Yields:
+            Iterator[CheckpointTuple]: An iterator of matching checkpoint tuples.
+        """
+        aiter_ = self.alist(config, filter=filter, before=before, limit=limit)
+        while True:
+            try:
+                yield asyncio.run_coroutine_threadsafe(
+                    cast(Any, anext(aiter_)),
+                    self.loop,
+                ).result()
+            except StopAsyncIteration:
+                break
+
+    def get_tuple(self, config: RunnableConfig) -> Optional[CheckpointTuple]:
+        """Get a checkpoint tuple from the database.
+
+        This method retrieves a checkpoint tuple from the MongoDB database based on
+        the provided config. If the config contains a "checkpoint_id" key, the
+        checkpoint with the matching thread ID and "checkpoint_id" is retrieved.
+        Otherwise, the latest checkpoint for the given thread ID is retrieved.
+
+        Args:
+            config (RunnableConfig): The config to use for retrieving the checkpoint.
+
+        Returns:
+            Optional[CheckpointTuple]: The retrieved checkpoint tuple, or None if no matching checkpoint was found.
+        """
+        try:
+            # check if we are in the main thread, only bg threads can block
+            # we don't check in other methods to avoid the overhead
+            if asyncio.get_running_loop() is self.loop:
+                raise asyncio.InvalidStateError(
+                    "Synchronous calls to AsyncMongoDBSaver are only allowed from a "
+                    "different thread. From the main thread, use the async interface."
+                    "For example, use `await checkpointer.aget_tuple(...)` or `await "
+                    "graph.ainvoke(...)`."
+                )
+        except RuntimeError:
+            pass
+        return asyncio.run_coroutine_threadsafe(
+            self.aget_tuple(config), self.loop
+        ).result()
+
+    def put(
+        self,
+        config: RunnableConfig,
+        checkpoint: Checkpoint,
+        metadata: CheckpointMetadata,
+        new_versions: ChannelVersions,
+    ) -> RunnableConfig:
+        """Save a checkpoint to the database.
+
+        This method saves a checkpoint to the MongoDB database. The checkpoint
+        is associated with the provided config and its parent config (if any).
+
+        Args:
+            config (RunnableConfig): The config to associate with the checkpoint.
+            checkpoint (Checkpoint): The checkpoint to save.
+            metadata (CheckpointMetadata): Additional metadata to save with the checkpoint.
+            new_versions (ChannelVersions): New channel versions as of this write.
+
+        Returns:
+            RunnableConfig: Updated configuration after storing the checkpoint.
+        """
+        return asyncio.run_coroutine_threadsafe(
+            self.aput(config, checkpoint, metadata, new_versions), self.loop
+        ).result()
+
+    def put_writes(
+        self,
+        config: RunnableConfig,
+        writes: Sequence[tuple[str, Any]],
+        task_id: str,
+        task_path: str = "",
+    ) -> None:
+        """Store intermediate writes linked to a checkpoint.
+
+        This method saves intermediate writes associated with a checkpoint to the database.
+
+        Args:
+            config (RunnableConfig): Configuration of the related checkpoint.
+            writes (Sequence[tuple[str, Any]]): List of writes to store, each as (channel, value) pair.
+            task_id (str): Identifier for the task creating the writes.
+        """
+        return asyncio.run_coroutine_threadsafe(
+            self.aput_writes(config, writes, task_id, task_path), self.loop
+        ).result()

--- a/libs/langgraph-checkpoint-mongodb/langgraph/checkpoint/mongodb/aio.py
+++ b/libs/langgraph-checkpoint-mongodb/langgraph/checkpoint/mongodb/aio.py
@@ -24,12 +24,7 @@ from langgraph.checkpoint.base import (
     get_checkpoint_id,
 )
 
-from .utils import (
-    DRIVER_METADATA,
-    _append_client_metadata,
-    dumps_metadata,
-    loads_metadata,
-)
+from .utils import DRIVER_METADATA, dumps_metadata, loads_metadata
 
 if sys.version_info >= (3, 10):
     anext = builtins.anext
@@ -105,7 +100,8 @@ class AsyncMongoDBSaver(BaseCheckpointSaver):
         self.ttl = ttl
 
         # append_metadata was added in PyMongo 4.14.0, but is a valid database name on earlier versions
-        _append_client_metadata(self.client)
+        if callable(getattr(self.client, "append_metadata", None)):
+            self.client.append_metadata(DRIVER_METADATA)
 
     async def _setup(self) -> None:
         """Create indexes if not present."""
@@ -258,7 +254,7 @@ class AsyncMongoDBSaver(BaseCheckpointSaver):
             return CheckpointTuple(
                 {"configurable": config_values},
                 checkpoint,
-                loads_metadata(doc["metadata"]),
+                loads_metadata(self.serde, doc["metadata"]),
                 (
                     {
                         "configurable": {
@@ -305,7 +301,7 @@ class AsyncMongoDBSaver(BaseCheckpointSaver):
 
         if filter:
             for key, value in filter.items():
-                query[f"metadata.{key}"] = dumps_metadata(value)
+                query[f"metadata.{key}"] = dumps_metadata(self.serde, value)
 
         if before is not None:
             query["checkpoint_id"] = {"$lt": before["configurable"]["checkpoint_id"]}
@@ -339,7 +335,7 @@ class AsyncMongoDBSaver(BaseCheckpointSaver):
                     }
                 },
                 checkpoint=self.serde.loads_typed((doc["type"], doc["checkpoint"])),
-                metadata=loads_metadata(doc["metadata"]),
+                metadata=loads_metadata(self.serde, doc["metadata"]),
                 parent_config=(
                     {
                         "configurable": {
@@ -389,7 +385,7 @@ class AsyncMongoDBSaver(BaseCheckpointSaver):
                 "parent_checkpoint_id": config["configurable"].get("checkpoint_id"),
                 "type": type_,
                 "checkpoint": serialized_checkpoint,
-                "metadata": dumps_metadata(metadata),
+                "metadata": dumps_metadata(self.serde, metadata),
                 "is_chunked": False,
             }
         else:
@@ -406,7 +402,7 @@ class AsyncMongoDBSaver(BaseCheckpointSaver):
             doc = {
                 "parent_checkpoint_id": config["configurable"].get("checkpoint_id"),
                 "type": type_,
-                "metadata": dumps_metadata(metadata),
+                "metadata": dumps_metadata(self.serde, metadata),
                 "is_chunked": True,
                 "chunk_key": chunk_key,
                 "num_chunks": len(chunks),

--- a/libs/langgraph-checkpoint-mongodb/langgraph/checkpoint/mongodb/saver.py
+++ b/libs/langgraph-checkpoint-mongodb/langgraph/checkpoint/mongodb/saver.py
@@ -185,7 +185,7 @@ class MongoDBSaver(BaseCheckpointSaver):
                 conn_string,
                 driver=DRIVER_METADATA,
             )
-            yield MongoDBSaver(
+            yield cls(
                 client,
                 db_name,
                 checkpoint_collection_name,

--- a/libs/langgraph-checkpoint-mongodb/langgraph/checkpoint/mongodb/saver.py
+++ b/libs/langgraph-checkpoint-mongodb/langgraph/checkpoint/mongodb/saver.py
@@ -529,8 +529,10 @@ class MongoDBSaver(BaseCheckpointSaver):
                     filter=upsert_query,
                     update={set_method: update_doc},
                     upsert=True,
-                ))
-        self.writes_collection.bulk_write(operations)
+                )
+            )
+        for i in range(0, len(operations), 1000):
+            self.writes_collection.bulk_write(operations[i : i + 1000])
 
     def delete_thread(
         self,

--- a/libs/langgraph-checkpoint-mongodb/langgraph/checkpoint/mongodb/saver.py
+++ b/libs/langgraph-checkpoint-mongodb/langgraph/checkpoint/mongodb/saver.py
@@ -284,11 +284,33 @@ class MongoDBSaver(BaseCheckpointSaver):
             checkpoint = self.serde.loads_typed(
                 (doc["type"], serialized_checkpoint))
             serialized_writes = self.writes_collection.find(config_values)
-            pending_writes = [(
-                doc["task_id"],
-                doc["channel"],
-                self.serde.loads_typed((doc["type"], doc["value"])),
-            ) for doc in serialized_writes]
+            pending_writes = []
+            for wrt in serialized_writes:
+                if not wrt.get("is_chunked"):
+                    value = self.serde.loads_typed((wrt["type"], wrt["value"]))
+                else:
+                    chunk_key = wrt.get("chunk_key")
+                    num_chunks = wrt.get("num_chunks")
+                    if not chunk_key or not num_chunks:
+                        continue  # or log warning
+
+                    chunk_keys = [
+                        f"{chunk_key}_part_{i + 1}" for i in range(num_chunks)
+                    ]
+                    chunk_docs_cursor = self.chunk_collection.find(
+                        {"_id": {"$in": chunk_keys}}
+                    )
+                    docs_by_id = {
+                        doc["_id"]: doc["value"] for doc in chunk_docs_cursor
+                    }
+
+                    if len(docs_by_id) != num_chunks:
+                        continue  # or log warning
+
+                    reassembled = b"".join(docs_by_id[key] for key in chunk_keys)
+                    value = self.serde.loads_typed((wrt["type"], reassembled))
+
+                pending_writes.append((wrt["task_id"], wrt["channel"], value))
             return CheckpointTuple(
                 {"configurable": config_values},
                 checkpoint,
@@ -363,11 +385,33 @@ class MongoDBSaver(BaseCheckpointSaver):
                 "checkpoint_id": doc["checkpoint_id"],
             }
             serialized_writes = self.writes_collection.find(config_values)
-            pending_writes = [(
-                wrt["task_id"],
-                wrt["channel"],
-                self.serde.loads_typed((wrt["type"], wrt["value"])),
-            ) for wrt in serialized_writes]
+            pending_writes = []
+            for wrt in serialized_writes:
+                if not wrt.get("is_chunked"):
+                    value = self.serde.loads_typed((wrt["type"], wrt["value"]))
+                else:
+                    chunk_key = wrt.get("chunk_key")
+                    num_chunks = wrt.get("num_chunks")
+                    if not chunk_key or not num_chunks:
+                        continue
+
+                    chunk_keys = [
+                        f"{chunk_key}_part_{i + 1}" for i in range(num_chunks)
+                    ]
+                    chunk_docs_cursor = self.chunk_collection.find(
+                        {"_id": {"$in": chunk_keys}}
+                    )
+                    docs_by_id = {
+                        doc["_id"]: doc["value"] for doc in chunk_docs_cursor
+                    }
+
+                    if len(docs_by_id) != num_chunks:
+                        continue
+
+                    reassembled = b"".join(docs_by_id[key] for key in chunk_keys)
+                    value = self.serde.loads_typed((wrt["type"], reassembled))
+
+                pending_writes.append((wrt["task_id"], wrt["channel"], value))
 
             yield CheckpointTuple(
                 config={
@@ -495,6 +539,8 @@ class MongoDBSaver(BaseCheckpointSaver):
             task_id (str): Identifier for the task creating the writes.
             task_path (str): Path of the task creating the writes.
         """
+        from bson import ObjectId
+
         thread_id = config["configurable"]["thread_id"]
         checkpoint_ns = config["configurable"]["checkpoint_ns"]
         checkpoint_id = config["configurable"]["checkpoint_id"]
@@ -503,6 +549,7 @@ class MongoDBSaver(BaseCheckpointSaver):
                           for w in writes) else "$setOnInsert")
         operations = []
         now = datetime.now(tz=timezone.utc)
+        chunk_size = 800 * 1024
         for idx, (channel, value) in enumerate(writes):
             upsert_query = {
                 "thread_id": thread_id,
@@ -515,19 +562,40 @@ class MongoDBSaver(BaseCheckpointSaver):
 
             type_, serialized_value = self.serde.dumps_typed(value)
 
-            update_doc: dict[str, Any] = {
-                "channel": channel,
-                "type": type_,
-                "value": serialized_value,
-            }
-
-            if self.ttl:
-                update_doc["created_at"] = now
+            if len(serialized_value) <= chunk_size:
+                doc = {
+                    "channel": channel,
+                    "type": type_,
+                    "value": serialized_value,
+                    "is_chunked": False,
+                }
+                if self.ttl:
+                    doc["created_at"] = now
+            else:
+                chunk_key = str(ObjectId())
+                chunks = [
+                    serialized_value[i : i + chunk_size]
+                    for i in range(0, len(serialized_value), chunk_size)
+                ]
+                chunk_docs = [
+                    {"_id": f"{chunk_key}_part_{i + 1}", "value": chunk}
+                    for i, chunk in enumerate(chunks)
+                ]
+                self.chunk_collection.insert_many(chunk_docs)
+                doc = {
+                    "channel": channel,
+                    "type": type_,
+                    "is_chunked": True,
+                    "chunk_key": chunk_key,
+                    "num_chunks": len(chunks),
+                }
+                if self.ttl:
+                    doc["created_at"] = now
 
             operations.append(
                 UpdateOne(
-                    filter=upsert_query,
-                    update={set_method: update_doc},
+                    upsert_query,
+                    {set_method: doc},
                     upsert=True,
                 )
             )

--- a/libs/langgraph-checkpoint-mongodb/langgraph/checkpoint/mongodb/saver.py
+++ b/libs/langgraph-checkpoint-mongodb/langgraph/checkpoint/mongodb/saver.py
@@ -379,6 +379,26 @@ class MongoDBSaver(BaseCheckpointSaver):
             sort=[("checkpoint_id", -1)])
 
         for doc in result:
+            if not doc.get("is_chunked"):
+                serialized_checkpoint = doc["checkpoint"]
+            else:
+                chunk_key = doc.get("chunk_key")
+                num_chunks = doc.get("num_chunks")
+                if not chunk_key or not num_chunks:
+                    continue
+
+                chunk_keys = [f"{chunk_key}_part_{i + 1}" for i in range(num_chunks)]
+                chunk_docs_cursor = self.chunk_collection.find(
+                    {"_id": {"$in": chunk_keys}}
+                )
+                docs_by_id = {doc["_id"]: doc["value"] for doc in chunk_docs_cursor}
+
+                if len(docs_by_id) != num_chunks:
+                    continue
+
+                reassembled = b"".join(docs_by_id[key] for key in chunk_keys)
+                serialized_checkpoint = reassembled
+
             config_values = {
                 "thread_id": doc["thread_id"],
                 "checkpoint_ns": doc["checkpoint_ns"],
@@ -414,16 +434,9 @@ class MongoDBSaver(BaseCheckpointSaver):
                 pending_writes.append((wrt["task_id"], wrt["channel"], value))
 
             yield CheckpointTuple(
-                config={
-                    "configurable": {
-                        "thread_id": doc["thread_id"],
-                        "checkpoint_ns": doc["checkpoint_ns"],
-                        "checkpoint_id": doc["checkpoint_id"],
-                    }
-                },
-                checkpoint=self.serde.loads_typed(
-                    (doc["type"], doc["checkpoint"])),
-                metadata=loads_metadata(self.serde, doc["metadata"]),
+                config={"configurable": config_values},
+                checkpoint=self.serde.loads_typed((doc["type"], serialized_checkpoint)),
+                metadata=loads_metadata(doc["metadata"]),
                 parent_config=({
                     "configurable": {
                         "thread_id": doc["thread_id"],

--- a/libs/langgraph-checkpoint-mongodb/langgraph/checkpoint/mongodb/saver.py
+++ b/libs/langgraph-checkpoint-mongodb/langgraph/checkpoint/mongodb/saver.py
@@ -53,10 +53,8 @@ def _create_saver_indexes(
         ttl_index = [("created_at", ASCENDING)]
         found = False
         for idx in indexes:
-            if (
-                index_key_list(idx) == tuple(ttl_index)
-                and idx.get("expireAfterSeconds") == ttl
-            ):
+            if (index_key_list(idx) == tuple(ttl_index)
+                    and idx.get("expireAfterSeconds") == ttl):
                 found = True
                 break
         if not found:
@@ -129,6 +127,7 @@ class MongoDBSaver(BaseCheckpointSaver):
         self.db = self.client[db_name]
         self.checkpoint_collection = self.db[checkpoint_collection_name]
         self.writes_collection = self.db[writes_collection_name]
+        self.chunk_collection = self.db[f"{checkpoint_collection_name}_chunks"]
         self.ttl = ttl
         if serde is not None:
             self.serde = serde
@@ -247,40 +246,60 @@ class MongoDBSaver(BaseCheckpointSaver):
         else:
             query = {"thread_id": thread_id, "checkpoint_ns": checkpoint_ns}
 
-        result = self.checkpoint_collection.find(
-            query, sort=[("checkpoint_id", -1)], limit=1
-        )
+        result = self.checkpoint_collection.find(query,
+                                                 sort=[("checkpoint_id", -1)],
+                                                 limit=1)
         for doc in result:
             config_values = {
                 "thread_id": thread_id,
                 "checkpoint_ns": checkpoint_ns,
                 "checkpoint_id": doc["checkpoint_id"],
             }
-            checkpoint = self.serde.loads_typed((doc["type"], doc["checkpoint"]))
+            if not doc.get("is_chunked"):
+                serialized_checkpoint = doc["checkpoint"]
+            else:
+                chunk_key = doc.get("chunk_key")
+                num_chunks = doc.get("num_chunks")
+                if not chunk_key or not num_chunks:
+                    return None
+
+                chunk_keys = [
+                    f"{chunk_key}_part_{i + 1}" for i in range(num_chunks)
+                ]
+                chunk_docs_cursor = self.chunk_collection.find(
+                    {"_id": {
+                        "$in": chunk_keys
+                    }})
+                docs_by_id = {
+                    doc["_id"]: doc["value"]
+                    for doc in chunk_docs_cursor
+                }
+
+                if len(docs_by_id) != num_chunks:
+                    return None
+
+                reassembled = b"".join(docs_by_id[key] for key in chunk_keys)
+                serialized_checkpoint = reassembled
+
+            checkpoint = self.serde.loads_typed(
+                (doc["type"], serialized_checkpoint))
             serialized_writes = self.writes_collection.find(config_values)
-            pending_writes = [
-                (
-                    doc["task_id"],
-                    doc["channel"],
-                    self.serde.loads_typed((doc["type"], doc["value"])),
-                )
-                for doc in serialized_writes
-            ]
+            pending_writes = [(
+                doc["task_id"],
+                doc["channel"],
+                self.serde.loads_typed((doc["type"], doc["value"])),
+            ) for doc in serialized_writes]
             return CheckpointTuple(
                 {"configurable": config_values},
                 checkpoint,
                 loads_metadata(self.serde, doc["metadata"]),
-                (
-                    {
-                        "configurable": {
-                            "thread_id": thread_id,
-                            "checkpoint_ns": checkpoint_ns,
-                            "checkpoint_id": doc["parent_checkpoint_id"],
-                        }
+                ({
+                    "configurable": {
+                        "thread_id": thread_id,
+                        "checkpoint_ns": checkpoint_ns,
+                        "checkpoint_id": doc["parent_checkpoint_id"],
                     }
-                    if doc.get("parent_checkpoint_id")
-                    else None
-                ),
+                } if doc.get("parent_checkpoint_id") else None),
                 pending_writes,
             )
 
@@ -320,18 +339,22 @@ class MongoDBSaver(BaseCheckpointSaver):
             if "thread_id" in config["configurable"]:
                 query["thread_id"] = config["configurable"]["thread_id"]
             if "checkpoint_ns" in config["configurable"]:
-                query["checkpoint_ns"] = config["configurable"]["checkpoint_ns"]
+                query["checkpoint_ns"] = config["configurable"][
+                    "checkpoint_ns"]
 
         if filter:
             for key, value in filter.items():
                 query[f"metadata.{key}"] = dumps_metadata(self.serde, value)
 
         if before is not None:
-            query["checkpoint_id"] = {"$lt": before["configurable"]["checkpoint_id"]}
+            query["checkpoint_id"] = {
+                "$lt": before["configurable"]["checkpoint_id"]
+            }
 
         result = self.checkpoint_collection.find(
-            query, limit=0 if limit is None else limit, sort=[("checkpoint_id", -1)]
-        )
+            query,
+            limit=0 if limit is None else limit,
+            sort=[("checkpoint_id", -1)])
 
         for doc in result:
             config_values = {
@@ -340,14 +363,11 @@ class MongoDBSaver(BaseCheckpointSaver):
                 "checkpoint_id": doc["checkpoint_id"],
             }
             serialized_writes = self.writes_collection.find(config_values)
-            pending_writes = [
-                (
-                    wrt["task_id"],
-                    wrt["channel"],
-                    self.serde.loads_typed((wrt["type"], wrt["value"])),
-                )
-                for wrt in serialized_writes
-            ]
+            pending_writes = [(
+                wrt["task_id"],
+                wrt["channel"],
+                self.serde.loads_typed((wrt["type"], wrt["value"])),
+            ) for wrt in serialized_writes]
 
             yield CheckpointTuple(
                 config={
@@ -357,19 +377,16 @@ class MongoDBSaver(BaseCheckpointSaver):
                         "checkpoint_id": doc["checkpoint_id"],
                     }
                 },
-                checkpoint=self.serde.loads_typed((doc["type"], doc["checkpoint"])),
+                checkpoint=self.serde.loads_typed(
+                    (doc["type"], doc["checkpoint"])),
                 metadata=loads_metadata(self.serde, doc["metadata"]),
-                parent_config=(
-                    {
-                        "configurable": {
-                            "thread_id": doc["thread_id"],
-                            "checkpoint_ns": doc["checkpoint_ns"],
-                            "checkpoint_id": doc["parent_checkpoint_id"],
-                        }
+                parent_config=({
+                    "configurable": {
+                        "thread_id": doc["thread_id"],
+                        "checkpoint_ns": doc["checkpoint_ns"],
+                        "checkpoint_id": doc["parent_checkpoint_id"],
                     }
-                    if doc.get("parent_checkpoint_id")
-                    else None
-                ),
+                } if doc.get("parent_checkpoint_id") else None),
                 pending_writes=pending_writes,
             )
 
@@ -404,18 +421,45 @@ class MongoDBSaver(BaseCheckpointSaver):
             >>> print(saved_config)
             {'configurable': {'thread_id': '1', 'checkpoint_ns': '', 'checkpoint_id': '1ef4f797-8335-6428-8001-8a1503f9b875'}}
         """
+        from bson import ObjectId
+
         thread_id = config["configurable"]["thread_id"]
         checkpoint_ns = config["configurable"]["checkpoint_ns"]
         checkpoint_id = checkpoint["id"]
         type_, serialized_checkpoint = self.serde.dumps_typed(checkpoint)
         metadata = metadata.copy()
         metadata.update(config.get("metadata", {}))
-        doc = {
-            "parent_checkpoint_id": config["configurable"].get("checkpoint_id"),
-            "type": type_,
-            "checkpoint": serialized_checkpoint,
-            "metadata": dumps_metadata(self.serde, metadata),
-        }
+
+        chunk_size = 800 * 1024
+        if len(serialized_checkpoint) <= chunk_size:
+            doc = {
+                "parent_checkpoint_id":
+                config["configurable"].get("checkpoint_id"),
+                "type": type_,
+                "checkpoint": serialized_checkpoint,
+                "metadata": dumps_metadata(self.serde, metadata),
+                "is_chunked": False,
+            }
+        else:
+            chunk_key = str(ObjectId())
+            chunks = [
+                serialized_checkpoint[i:i + chunk_size]
+                for i in range(0, len(serialized_checkpoint), chunk_size)
+            ]
+            chunk_docs = [{
+                "_id": f"{chunk_key}_part_{i + 1}",
+                "value": chunk
+            } for i, chunk in enumerate(chunks)]
+            self.chunk_collection.insert_many(chunk_docs)
+            doc = {
+                "parent_checkpoint_id":
+                config["configurable"].get("checkpoint_id"),
+                "type": type_,
+                "metadata": dumps_metadata(self.serde, metadata),
+                "is_chunked": True,
+                "chunk_key": chunk_key,
+                "num_chunks": len(chunks),
+            }
         upsert_query = {
             "thread_id": thread_id,
             "checkpoint_ns": checkpoint_ns,
@@ -424,7 +468,8 @@ class MongoDBSaver(BaseCheckpointSaver):
         if self.ttl:
             doc["created_at"] = datetime.now(tz=timezone.utc)
 
-        self.checkpoint_collection.update_one(upsert_query, {"$set": doc}, upsert=True)
+        self.checkpoint_collection.update_one(upsert_query, {"$set": doc},
+                                              upsert=True)
         return {
             "configurable": {
                 "thread_id": thread_id,
@@ -454,8 +499,8 @@ class MongoDBSaver(BaseCheckpointSaver):
         checkpoint_ns = config["configurable"]["checkpoint_ns"]
         checkpoint_id = config["configurable"]["checkpoint_id"]
         set_method = (  # Allow replacement on existing writes only if there were errors.
-            "$set" if all(w[0] in WRITES_IDX_MAP for w in writes) else "$setOnInsert"
-        )
+            "$set" if all(w[0] in WRITES_IDX_MAP
+                          for w in writes) else "$setOnInsert")
         operations = []
         now = datetime.now(tz=timezone.utc)
         for idx, (channel, value) in enumerate(writes):
@@ -484,8 +529,7 @@ class MongoDBSaver(BaseCheckpointSaver):
                     filter=upsert_query,
                     update={set_method: update_doc},
                     upsert=True,
-                )
-            )
+                ))
         self.writes_collection.bulk_write(operations)
 
     def delete_thread(
@@ -503,7 +547,8 @@ class MongoDBSaver(BaseCheckpointSaver):
         # Delete all writes associated with the thread ID
         self.writes_collection.delete_many({"thread_id": thread_id})
 
-    async def aget_tuple(self, config: RunnableConfig) -> Optional[CheckpointTuple]:
+    async def aget_tuple(self,
+                         config: RunnableConfig) -> Optional[CheckpointTuple]:
         """Asynchronously fetch a checkpoint tuple using the given configuration.
 
         Asynchronously wraps the blocking `self.get_tuple` method.
@@ -548,12 +593,14 @@ class MongoDBSaver(BaseCheckpointSaver):
 
         def run() -> None:
             try:
-                for item in self.list(
-                    config, filter=filter, before=before, limit=limit
-                ):
+                for item in self.list(config,
+                                      filter=filter,
+                                      before=before,
+                                      limit=limit):
                     loop.call_soon_threadsafe(queue.put_nowait, item)
             finally:
-                loop.call_soon_threadsafe(queue.put_nowait, sentinel)  # type: ignore
+                loop.call_soon_threadsafe(queue.put_nowait,
+                                          sentinel)  # type: ignore
 
         await run_in_executor(None, run)
         while True:
@@ -582,9 +629,8 @@ class MongoDBSaver(BaseCheckpointSaver):
         Returns:
             RunnableConfig: Updated configuration after storing the checkpoint.
         """
-        return await run_in_executor(
-            None, self.put, config, checkpoint, metadata, new_versions
-        )
+        return await run_in_executor(None, self.put, config, checkpoint,
+                                     metadata, new_versions)
 
     async def aput_writes(
         self,
@@ -603,9 +649,8 @@ class MongoDBSaver(BaseCheckpointSaver):
             task_id: Identifier for the task creating the writes.
             task_path: Path of the task creating the writes.
         """
-        return await run_in_executor(
-            None, self.put_writes, config, writes, task_id, task_path
-        )
+        return await run_in_executor(None, self.put_writes, config, writes,
+                                     task_id, task_path)
 
     async def adelete_thread(
         self,

--- a/libs/langgraph-checkpoint-mongodb/langgraph/checkpoint/mongodb/utils.py
+++ b/libs/langgraph-checkpoint-mongodb/langgraph/checkpoint/mongodb/utils.py
@@ -35,6 +35,10 @@ def loads_metadata(
 
     metadata is stored in MongoDB collection with string keys and
     serde serialized keys.
+
+    Supports both:
+    - New format (v0.2.2+): tuple/list of (type, bytes), e.g., ("msgpack", b'...')
+    - Old format (<=v0.2.1): just bytes, e.g., b'"loop"' (assumes "json" type)
     """
     if isinstance(metadata, dict):
         output = dict()
@@ -42,7 +46,16 @@ def loads_metadata(
             output[key] = loads_metadata(serde, value)
         return output
     else:
-        return serde.loads_typed(metadata)
+        # Handle both old format (just bytes) and new format (tuple/list of type, bytes)
+        if isinstance(metadata, (tuple, list)) and len(metadata) == 2:
+            # New format: (type, bytes)
+            return serde.loads_typed(metadata)
+        elif isinstance(metadata, bytes):
+            # Old format: just bytes, assume "json" type for backward compatibility
+            return serde.loads_typed(("json", metadata))
+        else:
+            # Fallback: try as-is (may fail, but preserves original behavior)
+            return serde.loads_typed(metadata)
 
 
 def dumps_metadata(

--- a/libs/langgraph-checkpoint-mongodb/langgraph/checkpoint/mongodb/utils.py
+++ b/libs/langgraph-checkpoint-mongodb/langgraph/checkpoint/mongodb/utils.py
@@ -6,6 +6,8 @@ Utilities for langchain-checkpoint-mongod.
 from importlib.metadata import version
 from typing import Any, Union
 
+from pymongo.driver_info import DriverInfo
+
 from langgraph.checkpoint.base import CheckpointMetadata
 from langgraph.checkpoint.serde.base import SerializerProtocol
 from pymongo import AsyncMongoClient

--- a/libs/langgraph-store-mongodb/langgraph/store/mongodb/base.py
+++ b/libs/langgraph-store-mongodb/langgraph/store/mongodb/base.py
@@ -171,6 +171,9 @@ class MongoDBStore(BaseStore):
         """
 
         self.collection = collection
+        self.chunk_collection = self.collection.database[
+            f"{self.collection.name}_chunks"
+        ]
         self.ttl_config = {} if ttl_config is None else ttl_config
         self.index_config = {} if index_config is None else index_config
 
@@ -324,8 +327,35 @@ class MongoDBStore(BaseStore):
                 return_document=ReturnDocument.AFTER,
             )
         if res:
+            if not res.get("is_chunked"):
+                return Item(
+                    value=res["value"],
+                    key=res["key"],
+                    namespace=tuple(res["namespace"]),
+                    created_at=res["created_at"],
+                    updated_at=res["updated_at"],
+                )
+
+            chunk_key = res.get("chunk_key")
+            num_chunks = res.get("num_chunks")
+            if not chunk_key or not num_chunks:
+                return None
+
+            chunk_keys = [f"{chunk_key}_part_{i + 1}" for i in range(num_chunks)]
+            chunk_docs_cursor = self.chunk_collection.find(
+                {"_id": {"$in": chunk_keys}}
+            )
+            docs_by_id = {doc["_id"]: doc["value"] for doc in chunk_docs_cursor}
+
+            if len(docs_by_id) != num_chunks:
+                return None
+
+            reassembled = b"".join(docs_by_id[key] for key in chunk_keys)
+            from bson import BSON
+
+            value = BSON(reassembled).decode()
             return Item(
-                value=res["value"],
+                value=value,
                 key=res["key"],
                 namespace=tuple(res["namespace"]),
                 created_at=res["created_at"],
@@ -507,6 +537,8 @@ class MongoDBStore(BaseStore):
                         offset=op.offset,
                     )
                 )
+        from bson import BSON, ObjectId
+
         # Apply puts and deletes in bulk
         # Extract texts to embed for each op
         if self.index_config:
@@ -522,13 +554,37 @@ class MongoDBStore(BaseStore):
                 )
             else:
                 # Add or Upsert the value
-                to_set = {
-                    "value": op.value,
-                    "updated_at": datetime.now(tz=timezone.utc),
-                }
+                serialized_val = BSON.encode(op.value)
+                chunk_size = 800 * 1024
+
+                if len(serialized_val) <= chunk_size:
+                    to_set = {
+                        "value": op.value,
+                        "updated_at": datetime.now(tz=timezone.utc),
+                        "is_chunked": False,
+                    }
+                else:
+                    chunk_key = str(ObjectId())
+                    chunks = [
+                        serialized_val[i : i + chunk_size]
+                        for i in range(0, len(serialized_val), chunk_size)
+                    ]
+                    chunk_docs = [
+                        {"_id": f"{chunk_key}_part_{i + 1}", "value": chunk}
+                        for i, chunk in enumerate(chunks)
+                    ]
+                    self.chunk_collection.insert_many(chunk_docs)
+                    to_set = {
+                        "updated_at": datetime.now(tz=timezone.utc),
+                        "is_chunked": True,
+                        "chunk_key": chunk_key,
+                        "num_chunks": len(chunks),
+                    }
+
                 if self.index_config:
-                    embed = texts[v] if self._is_autoembedding else vectors[v]
-                    to_set[self._embedding_key] = embed
+                    if not to_set.get("is_chunked"):
+                        embed = texts[v] if self._is_autoembedding else vectors[v]
+                        to_set[self._embedding_key] = embed
                     to_set["namespace_prefix"] = self._denormalize_path(op.namespace)
                     v += 1
 
@@ -675,17 +731,49 @@ class MongoDBStore(BaseStore):
 
         results = self.collection.aggregate(pipeline)
 
-        return [
-            SearchItem(
-                namespace=tuple(res["namespace"]),
-                key=res["key"],
-                value=res["value"],
-                created_at=res["created_at"],
-                updated_at=res["updated_at"],
-                score=res.get("score"),
-            )
-            for res in results
-        ]
+        items = []
+        for res in results:
+            if not res.get("is_chunked"):
+                items.append(
+                    SearchItem(
+                        namespace=tuple(res["namespace"]),
+                        key=res["key"],
+                        value=res["value"],
+                        created_at=res["created_at"],
+                        updated_at=res["updated_at"],
+                        score=res.get("score"),
+                    )
+                )
+            else:
+                chunk_key = res.get("chunk_key")
+                num_chunks = res.get("num_chunks")
+                if not chunk_key or not num_chunks:
+                    continue
+
+                chunk_keys = [f"{chunk_key}_part_{i + 1}" for i in range(num_chunks)]
+                chunk_docs_cursor = self.chunk_collection.find(
+                    {"_id": {"$in": chunk_keys}}
+                )
+                docs_by_id = {doc["_id"]: doc["value"] for doc in chunk_docs_cursor}
+
+                if len(docs_by_id) != num_chunks:
+                    continue
+
+                reassembled = b"".join(docs_by_id[key] for key in chunk_keys)
+                from bson import BSON
+
+                value = BSON(reassembled).decode()
+                items.append(
+                    SearchItem(
+                        namespace=tuple(res["namespace"]),
+                        key=res["key"],
+                        value=value,
+                        created_at=res["created_at"],
+                        updated_at=res["updated_at"],
+                        score=res.get("score"),
+                    )
+                )
+        return items
 
     def _denormalize_path(self, paths: Union[tuple[str, ...], list[str]]) -> list[str]:
         """Create list of path parents, for use in $vectorSearch filter.


### PR DESCRIPTION
rebase to langchain-mongodb latest.

Tested with LangGraph==1.0.7
Fixed a `langgraph.checkpoint.serde.jsonplus.JsonPlusSerializer` `loads_typed` backward compatibility issue. Tested locally and on QE6, old and new chat requests.