### PR TITLE
Bump pypdf to 6.15.0 for GHSA-fp3f-mc75-235c and GHSA-fwg2-594c-jp42

### DIFF
--- a/libs/langchain-mongodb/pyproject.toml
+++ b/libs/langchain-mongodb/pyproject.toml
@@ -36,7 +36,8 @@ dev = [
     "langchain-ollama>=0.2.2",
     "langchain-openai>=0.2.14",
     "langchain-community>=0.3.27",
-    "pypdf>=5.0.1",
+    # Floor covers GHSA-fp3f-mc75-235c + GHSA-fwg2-594c-jp42 (both fixed in 6.15.0).
+    "pypdf>=6.15.0",
     "langgraph>=0.2.72",
     "flaky>=3.8.1",
     "langchain-tests==0.3.20",

--- a/libs/langchain-mongodb/uv.lock
+++ b/libs/langchain-mongodb/uv.lock
@@ -885,7 +885,7 @@ dev = [
     { name = "mypy", specifier = ">=1.10" },
     { name = "pip", specifier = ">=25.0.1" },
     { name = "pre-commit", specifier = ">=4.0" },
-    { name = "pypdf", specifier = ">=5.0.1" },
+    { name = "pypdf", specifier = ">=6.15.0" },
     { name = "pytest", specifier = ">=7.3.0" },
     { name = "pytest-asyncio", specifier = ">=0.21.1" },
     { name = "pytest-mock", specifier = ">=3.10.0" },
@@ -1905,14 +1905,14 @@ wheels = [
 
 [[package]]
 name = "pypdf"
-version = "6.14.2"
+version = "6.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/03/72/7dfd5ff1c9c37de97a731701f51af091325f123d9d4270361c9c69e4431f/pypdf-6.14.2.tar.gz", hash = "sha256:7873f502fe4385e79539b21d872392dc0c4e3714327c15881cbc7fbfd1f95b25", size = 6491182, upload-time = "2026-06-23T14:18:30.859Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/17/ee75a92718ec7212de831e71454d702225aa5e474a805cce169806044453/pypdf-6.15.0.tar.gz", hash = "sha256:d39c4d955a76409284a905e2d65b40076d77ab76129e0faaeeb6612403ecfc79", size = 6993794, upload-time = "2026-08-06T13:06:49.929Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/e6/136aa8993a2ae7214e0b0ef2edaa0d2e08d1d4e4982635b08a835ff31ec8/pypdf-6.14.2-py3-none-any.whl", hash = "sha256:3f07891af76dc002657e04993ab9b4de81de29f9013b9761d0b7968bff12e946", size = 349514, upload-time = "2026-06-23T14:18:28.867Z" },
+    { url = "https://files.pythonhosted.org/packages/af/72/ce3067ac31e214a66388159f8462ddb8c13dd00170f24d555a1f1ae8ee91/pypdf-6.15.0-py3-none-any.whl", hash = "sha256:14e001d6504822cb1ca9c7ed9a69bccb320f59b320730f55af804361abe4d5ee", size = 378123, upload-time = "2026-08-06T13:06:47.709Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes the two open Dependabot alerts on `libs/langchain-mongodb/uv.lock`. Both advisories are fixed in pypdf 6.15.0, which is the current latest release.

Raises the dev-group floor as well as the lock so a fresh resolve cannot land back on a vulnerable version.

## Scope

pypdf sits in `[dependency-groups] dev`, not `[project].dependencies`, so this never reached downstream consumers of the fork -- they resolve only the runtime deps (langchain-core, langchain, pymongo, langchain-text-splitters, numpy, lark). Exposure was limited to this repo's own test environment.

## Verification

`uv lock --upgrade-package pypdf` resolved 113 packages and changed exactly one:

```
Updated pypdf v6.14.2 -> v6.15.0
```

No source file in the repo imports pypdf, so resolution is the whole check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)